### PR TITLE
Add override for IncludeXmlComments for non-file-path

### DIFF
--- a/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
+++ b/Swashbuckle.Core/Application/SwaggerDocsConfig.cs
@@ -211,8 +211,12 @@ namespace Swashbuckle.Application
 
         public void IncludeXmlComments(string filePath)
         {
-            var lazyXmlDoc = new Lazy<XPathDocument>(() => new XPathDocument(filePath), isThreadSafe: true);
+            IncludeXmlComments(() => new XPathDocument(filePath));
+        }
 
+        public void IncludeXmlComments(Func<XPathDocument> factory)
+        {
+            var lazyXmlDoc = new Lazy<XPathDocument>(factory, isThreadSafe: true);
             OperationFilter(() => new ApplyXmlActionComments(lazyXmlDoc.Value));
             ModelFilter(() => new ApplyXmlTypeComments(lazyXmlDoc.Value));
         }


### PR DESCRIPTION
Add override for IncludeXmlComments to allow for adding xml comments derived from location other than file path.
